### PR TITLE
Disabling arrow keys so they do not scroll the page

### DIFF
--- a/src/components/Editor.js
+++ b/src/components/Editor.js
@@ -273,6 +273,12 @@ var customCompleter = {
 class Editor extends Component {
 
   componentDidMount() {
+    window.addEventListener("keydown", function (e) {
+      // space and arrow keys
+      if ([32, 37, 38, 39, 40].indexOf(e.keyCode) > -1) {
+        e.preventDefault();
+      }
+    }, false);
     this.refs.aceEditor.editor.completers = [customCompleter];
   }
 


### PR DESCRIPTION
Issue #56: Arrow keys move page in viewer.

I think disabling them is the right way to go, it still works in the scene though. I would like some help verifying this. 